### PR TITLE
fix bug on Windows:  TypeError: object of type 'WindowsPath' has no l…

### DIFF
--- a/pyshortcuts/shortcut.py
+++ b/pyshortcuts/shortcut.py
@@ -78,7 +78,7 @@ def shortcut(script, userfolders, name=None, description=None, folder=None,
 
     target = '%s.%s' % (name, scut_ext)
 
-    if icon is not None and len(icon) > 0:
+    if icon is not None and len(str(icon)) > 0:
         icon = os.path.abspath(icon)
         if not os.path.exists(icon):
             for ext in ico_ext:


### PR DESCRIPTION
fix this: 

File "D:\Users\Haujet\AppData\Local\Programs\Python\Python38\lib\site-packages\pyshortcuts\shortcut.py", line 81, in shortcut
    if icon is not None and len(icon) > 0:
TypeError: object of type 'WindowsPath' has no len()